### PR TITLE
[Per policy, PR is here pending "Before submitting" box 1] Update _safe_divide to allow Accuracy to run on the GPU

### DIFF
--- a/src/torchmetrics/utilities/compute.py
+++ b/src/torchmetrics/utilities/compute.py
@@ -56,7 +56,6 @@ def _safe_divide(num: Tensor, denom: Tensor, zero_division: float = 0.0) -> Tens
     """
     num = num if num.is_floating_point() else num.float()
     denom = denom if denom.is_floating_point() else denom.float()
-    zero_division = torch.tensor(zero_division).float().to(num.device)
     return torch.where(denom != 0, num / denom, zero_division)
 
 

--- a/tests/unittests/classification/test_accuracy.py
+++ b/tests/unittests/classification/test_accuracy.py
@@ -335,6 +335,57 @@ class TestMulticlassAccuracy(MetricTester):
             dtype=dtype,
         )
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires cuda")
+    @pytest.mark.parametrize("dtype", [torch.half, torch.double])
+    @pytest.mark.parametrize(["average", "use_deterministic_algorithms"], 
+                             [[None, True],  # Defaults to "macro", but explicitly included for testing omission
+                              ["macro", True],  # average=`macro` uses a different code path with `bincount` when not `use_deterministic` and incurs a CPU sync
+                              ["micro", False],
+                              ["micro", True],
+                              ["weighted", True],])
+    def test_multiclass_accuracy_gpu_sync_points(self, inputs, dtype: torch.dtype, average: str, use_deterministic_algorithms: bool):
+        """Test GPU support of the metric, avoiding CPU sync points."""
+        preds, target = inputs
+        
+        # Wrap the default functional to attach sync_debug_mode as run_precision_test_gpu handles moving data onto the GPU, so we cannot set the debug mode outside the call
+        def wrapped_multiclass_accuracy(
+            preds: torch.Tensor,
+            target: torch.Tensor,
+            num_classes: int,
+        ) -> torch.Tensor:
+            prev_sync_debug_mode = torch.cuda.get_sync_debug_mode()
+            torch.cuda.set_sync_debug_mode("error")
+            try:
+                validate_args = False  # `validate_args` will require CPU sync for exceptions
+                # average = average  #'micro'  # default is `macro` which uses a `_bincount` that does a CPU sync
+                torch.use_deterministic_algorithms(mode=use_deterministic_algorithms)  # uses a different path for average=`macro`, which avoids `bincount` and a CPU sync
+                return multiclass_accuracy(preds, target, num_classes, validate_args=validate_args, average=average)
+            finally:
+                torch.cuda.set_sync_debug_mode(prev_sync_debug_mode)
+        
+        self.run_precision_test_gpu(
+            preds=preds,
+            target=target,
+            metric_module=MulticlassAccuracy,
+            metric_functional=wrapped_multiclass_accuracy,
+            metric_args={"num_classes": NUM_CLASSES},
+            dtype=dtype,
+        )
+        
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires cuda")
+    @pytest.mark.parametrize("dtype", [torch.half, torch.double])
+    @pytest.mark.parametrize(["average", "use_deterministic_algorithms"], 
+                             [[None, False],  # If you remove from this collection, please add items to `test_multiclass_accuracy_gpu_sync_points`
+                              ["macro", False],
+                              ["weighted", False],])
+    def test_multiclass_accuracy_gpu_sync_points_uptodate(self, inputs, dtype: torch.dtype, average: str, use_deterministic_algorithms: bool):
+        """
+        Tests that `test_multiclass_accuracy_gpu_sync_points` is kept up to date, explicitly validates that known failures still fail, so that if they're fixed
+        they must be added to `test_multiclass_accuracy_gpu_sync_points`
+        """
+        with pytest.raises(RuntimeError, match="called a synchronizing CUDA operation"):
+            self.test_multiclass_accuracy_gpu_sync_points(inputs=inputs, dtype=dtype, average=average, use_deterministic_algorithms=use_deterministic_algorithms)
+
 
 _mc_k_target = torch.tensor([0, 1, 2])
 _mc_k_preds = torch.tensor([[0.35, 0.4, 0.25], [0.1, 0.5, 0.4], [0.2, 0.1, 0.7]])


### PR DESCRIPTION
Caused a CPU/GPU sync point. torch.where can accept the float directly

## What does this PR do?

Fixes #2638

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>Ensure CPU/GPU sync point avoided for Accuracy metric</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
