### PR TITLE
Typo fix

### DIFF
--- a/src/torchmetrics/functional/classification/stat_scores.py
+++ b/src/torchmetrics/functional/classification/stat_scores.py
@@ -291,7 +291,7 @@ def _multiclass_stat_scores_tensor_validation(
             )
         if multidim_average != "global" and preds.ndim < 3:
             raise ValueError(
-                "If `preds` have one dimension more than `target`, the shape of `preds` should "
+                "If `preds` have one dimension more than `target`, the shape of `preds` should be"
                 " at least 3D when multidim_average is set to `samplewise`"
             )
 
@@ -303,7 +303,7 @@ def _multiclass_stat_scores_tensor_validation(
             )
         if multidim_average != "global" and preds.ndim < 2:
             raise ValueError(
-                "When `preds` and `target` have the same shape, the shape of `preds` should "
+                "When `preds` and `target` have the same shape, the shape of `preds` should be"
                 " at least 2D when multidim_average is set to `samplewise`"
             )
     else:


### PR DESCRIPTION
## What does this PR do?

Fixes a cosmetic error in the error message

Previous: "If `preds` have one dimension more than `target`, the shape of `preds` should  at least 3D when multidim_average is set to `samplewise`"

Now: "If `preds` have one dimension more than `target`, the shape of `preds` should be at least 3D when multidim_average is set to `samplewise`"

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (**no need for typos** and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/torchmetrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
